### PR TITLE
reset padding and margin for map images to avoid offest images

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -254,6 +254,11 @@ p.bigtext {
     height:40em;
 }
 
+#map img {
+    margin:0;
+    padding: 0;
+}
+
 #map-searchbar {
     width: 100%;
     display: flex;


### PR DESCRIPTION
Fixes #84 with specific css for map images.