### PR TITLE
updating travis to cache exernal links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ branches:
   - master
   - dev
 
+cache:
+  directories:
+  - $TRAVIS_BUILD_DIR/tmp/.htmlproofer
+
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/scripts/travis_test
+++ b/scripts/travis_test
@@ -21,6 +21,7 @@ all_ignorable_urls = [
 
 options = {
    :assume_extension => true,
+   :cache => { :timeframe => "2w" },
    :url_ignore => all_ignorable_urls,
 }
 


### PR DESCRIPTION
Adding a cache to the htmlproofer external link checking should make it more reliable. External links will always be checked when first seen (ie. initially added to the site) and the positive result will be cached for a period of two weeks. This should mean flaky websites shouldn't be annoying and we can regularly have green builds.