### PR TITLE
Set margin to 0 for candidate card avatar image for consistent layout

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -442,6 +442,7 @@ p.bigtext {
 
           img {
             object-fit: cover;
+            margin: 0;
           }
 
           .image-placeholder {


### PR DESCRIPTION
Fix the candidate card avatar image margin issue when the avatar is present.

<img width="1265" height="366" alt="image" src="https://github.com/user-attachments/assets/77a54bf0-6f3c-460a-b2d2-a129f8f67ed8" />
candidate card

<img width="1965" height="517" alt="image" src="https://github.com/user-attachments/assets/3adc962f-fc3f-42c3-9229-eac7ae2c647d" />
election winners