### PR TITLE
add links to candidate cards

### DIFF
--- a/docs/_includes/candidate-card.html
+++ b/docs/_includes/candidate-card.html
@@ -1,4 +1,5 @@
 {% assign full_name = include.winner["Given_Names"] | append:" " | append:include.winner["Last_Name"] %}
+{% assign name_id = full_name | slugify %}
 
 {% assign race-info = site.data.internal.position-tags |
 where:"PositionUniqueName",include.winner["PositionUniqueName"] | first -%}
@@ -25,7 +26,13 @@ where:"PositionUniqueName",include.winner["PositionUniqueName"] | first -%}
                 </div>
                 <div class="meta">
                     <div class="name">
-                        <h3>{{ full_name }}</h3>
+                        {% if include.winner["Website"] %}
+                        <h3><a href="{{ include.winner['Website'] }}">{{ full_name }}</a></h3>
+                        {% else %}
+                        <h3 class="no-website" aria-describedby='{{ name_id }}-tooltip'>{{ full_name }}</h3>
+                        <div class="tooltip hidden" role="tooltip" id="{{ name_id }}-tooltip">This candidate does not have a listed website.
+                        </div>
+                        {% endif %}
                     </div>
                     {% if include.winner["Votes"] and include.winner["Percentage"] %}
                     {% assign percentage = include.winner["Percentage"] | append:"%" %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -91,6 +91,7 @@
 
     <script src="{{ site.baseurl }}/assets/js/jquery-3.6.0.min.js"></script>
     <script src="{{ site.baseurl }}/assets/js/hide-listings.js"></script>
+    <script src="{{ site.baseurl }}/assets/js/candidate-card.js"></script>
     <script src="{{ site.baseurl }}/assets/js/accordion.js"></script>
   </body>
 </html>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -595,10 +595,45 @@ p.bigtext {
         }
       }
 
+      .name {
+        position: relative;
+      }
+
       .name h3 {
         margin: 0 0 0.2em;
         font-size: 1.15em;
         line-height: 1.25;
+      }
+
+      .name h3 a {
+        color: inherit;
+      }
+
+      .name h3 a:hover {
+        text-decoration: underline;
+      }
+
+      .name h3 .no-website {
+        color: inherit;
+      }
+
+      .name .tooltip {
+        position: absolute;
+        top: 2rem;
+        left: 2rem;
+        background: $blue;
+        color: white;
+        width: 100%;
+        padding: 5px;
+        border: 1px solid black;
+        border-radius: 10px;
+        opacity: 1;
+        transition: opacity 0.6s ease, visibility 0.6s ease;
+      }
+
+      .name .hidden {
+        opacity: 0;
+        visibility: hidden;
       }
 
       .voting-result p {

--- a/docs/assets/js/candidate-card.js
+++ b/docs/assets/js/candidate-card.js
@@ -1,0 +1,12 @@
+$(document).ready(function () {
+    $("h3.no-website").on("click", (e) => {
+        tooltip_id = $(e.target).attr('aria-describedby');
+        tooltip_e = $("#" + tooltip_id)
+        if (tooltip_e.hasClass("hidden")) {
+            tooltip_e.removeClass("hidden");
+            setTimeout(() => {
+                tooltip_e.addClass("hidden");
+            }, 3000);
+        }
+    });
+});


### PR DESCRIPTION
Fixes Issue #136 

Since people are clicking it anyway, and because it's the person's name, I did not include any additional styling to denote it is a link.

<img width="1923" height="576" alt="Image" src="https://github.com/user-attachments/assets/a0a85da2-878d-4c68-a811-bd8c4892544b" />

On hover, the normal underline appears for candidates that have a link

<img width="374" height="239" alt="Image" src="https://github.com/user-attachments/assets/b59e09f0-1774-45e7-95ea-b357ccb6f7c3" />

it does not for candidates with no link.

If they click a candidate with no link anyway, a popup will fade in telling them there is no website.

<img width="462" height="326" alt="Image" src="https://github.com/user-attachments/assets/8a7452aa-33e2-4d64-a4c5-48969548dca7" />

stay for 3 seconds and then fade back out.

I wanted to avoid any appearance of bias.