### PR TITLE
Improve accessibility across navigation, worksheets, and ward tabs

### DIFF
--- a/docs/_includes/candidate-card.html
+++ b/docs/_includes/candidate-card.html
@@ -33,6 +33,7 @@ where:"PositionUniqueName",include.winner["PositionUniqueName"] | first -%}
                             have a listed website yet.</div>
                         {% endif %}
                         <button class="favourite-btn" data-candidate-id="{{ include.winner['UniqueID'] }}"
+                            aria-pressed="false"
                             aria-label="Favourite {{ full_name }}">
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </button>

--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -2,8 +2,13 @@
 From: https://christianspecht.de/2014/06/18/building-a-pseudo-dynamic-tree-menu-with-jekyll/
 {% endcomment %}
 {% assign navurl = page.url | remove: '.html' %}
-<div id="main-menu">
+<nav id="main-menu" aria-label="Main">
   <div class="inner">
+    <button id="main-menu-toggle" class="toggle-menu" type="button"
+      aria-controls="main-menu-ul" aria-expanded="false"
+      aria-label="Open main menu">
+      <i class="fas fa-bars" aria-hidden="true"></i>
+    </button>
     <ul id="main-menu-ul" class="hidden">
       {%- for item in site.data.internal.menu-layout %}
         <li><a href="{{ site.baseurl }}{{ item.url }}"
@@ -13,4 +18,4 @@ From: https://christianspecht.de/2014/06/18/building-a-pseudo-dynamic-tree-menu-
       {% endfor -%}
     </ul>
   </div>
-</div>
+</nav>

--- a/docs/_includes/ward-template.html
+++ b/docs/_includes/ward-template.html
@@ -139,8 +139,8 @@ you can vote for.
 
   {% endfor %}
 
-  <nav id="toc-tabs">
-    <div class="tab-strip">
+  <nav id="toc-tabs" aria-label="Candidate races">
+    <div class="tab-strip" role="tablist" aria-label="Candidate races">
       {% for race-id in races-split %}
 
         {% assign race-info = site.data.internal.position-tags |
@@ -149,8 +149,11 @@ you can vote for.
         {% if race-info.Grouping %}
         {% else %}
 
-          <a href="#{{ race-id | slugify }}-wrapper" id="{{ race-id | slugify }}-href" ><label class="tab-label {{ race-id | slugify }}" for="{{ race-id | slugify  }}">{{ race-info.PositionCategory
-          }}</label></a>
+          <label class="tab-label {{ race-id | slugify }}" id="{{ race-id | slugify }}-tab"
+            role="tab" tabindex="-1" aria-selected="false"
+            aria-controls="{{ race-id | slugify }}-wrapper"
+            for="{{ race-id | slugify  }}">{{ race-info.PositionCategory
+          }}</label>
           <br class="textonly"/>
         {% endif %}
       {% endfor %}
@@ -159,8 +162,10 @@ you can vote for.
         {% assign alias-info = site.data.internal.aliases | 
           where:"Alias",group | first %}
 
-        <a><label class="tab-label {{ group | slugify }}" for="{{ group
-        | slugify }}">{{ alias-info.ShortDesc }}</label></a>
+        <label class="tab-label {{ group | slugify }}" id="{{ group | slugify }}-tab"
+          role="tab" tabindex="-1" aria-selected="false"
+          aria-controls="{{ group | slugify }}-tabstrip"
+          for="{{ group | slugify }}">{{ alias-info.ShortDesc }}</label>
         <br class="textonly"/>
       {% endfor %}
     </div>
@@ -168,15 +173,20 @@ you can vote for.
     {% for group in groupings %}
         {% assign alias-info = site.data.internal.aliases | 
           where:"Alias",group | first %}
-        <div class="tab-strip substrip {{ group | slugify }}-tabstrip">
+        <div class="tab-strip substrip {{ group | slugify }}-tabstrip"
+          id="{{ group | slugify }}-tabstrip" role="tablist"
+          aria-label="{{ alias-info.ShortDesc }}">
           
           {% for race-id in races-split %}
             {% assign race-info = site.data.internal.position-tags |
               where:"PositionUniqueName",race-id | first -%}
 
             {% if race-info.Grouping and race-info.Grouping == group %}
-              <a href="#{{ race-id | slugify }}-wrapper" id="{{ race-id | slugify }}-href" ><label class="tab-label {{ race-id | slugify }}" for="{{ race-id | slugify  }}">{{ race-info.PositionCategory
-              }}</label></a>
+              <label class="tab-label {{ race-id | slugify }}" id="{{ race-id | slugify }}-tab"
+                role="tab" tabindex="-1" aria-selected="false"
+                aria-controls="{{ race-id | slugify }}-wrapper"
+                for="{{ race-id | slugify  }}">{{ race-info.PositionCategory
+              }}</label>
               <br class="textonly"/>
               
             {% endif %}
@@ -194,7 +204,8 @@ you can vote for.
       {% assign race-info = site.data.internal.position-tags |
       where:"PositionUniqueName",race-id | first -%}
 
-      <div class="race-wrapper tab-content" role="tabpanel" id="{{ race-id | slugify }}-wrapper">
+      <div class="race-wrapper tab-content" role="tabpanel" id="{{ race-id | slugify }}-wrapper"
+        aria-labelledby="{{ race-id | slugify }}-tab" tabindex="-1">
 
         {% include list-nominees.html race-id=race-id
            show-toc-link=true hide-details=false

--- a/docs/_includes/ward-template.html
+++ b/docs/_includes/ward-template.html
@@ -12,10 +12,12 @@ where:"PositionUniqueName",ward-id | first -%}
   <h3>Worksheet!</h3>
 </button>
 
-<div id="worksheets-panel" class="worksheets-panel aside-box blue" hidden>
+<div id="worksheets-panel" class="worksheets-panel aside-box blue" hidden
+  role="dialog" aria-modal="false" aria-labelledby="worksheets-panel-title"
+  tabindex="-1">
   <button class="worksheets-close" aria-label="Close worksheets panel">&times;</button>
   <header>
-    <h2>Candidate Worksheet</h2>
+    <h2 id="worksheets-panel-title">Candidate Worksheet</h2>
   </header>
   <p>
     <a target="_blank" href="../worksheets/worksheet-{{ ward-id }}.html">Click here</a> for a worksheet to help you keep track of

--- a/docs/_includes/worksheet-template.html
+++ b/docs/_includes/worksheet-template.html
@@ -89,8 +89,8 @@ where:"Name",ward-info.WardMunicipality | first %}
           {% for n in sorted-nominees %}
           <tr>
             <td class="cell">
-              <button class="favourite-btn" data-candidate-id="{{ n.UniqueID }}" aria-label="Favourite {{ n["
-                Given_Names"] }} {{ n["Last_Name"] }}">
+              <button class="favourite-btn" data-candidate-id="{{ n.UniqueID }}" aria-pressed="false"
+                aria-label="Favourite {{ n["Given_Names"] }} {{ n["Last_Name"] }}">
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </button>
             </td>
@@ -105,6 +105,7 @@ where:"Name",ward-info.WardMunicipality | first %}
             {%- endif -%}
             <td class="cell">
               <div class="auto-resize-textarea" contenteditable="true" role="textbox" aria-multiline="true"
+                aria-label="Notes for {{ n["Given_Names"] }} {{ n["Last_Name"] }}"
                 data-candidate-id="{{ n.UniqueID }}">
                 {%- if n.Withdrawn and n.Withdrawn == 'Y' %}
                 Candidate withdrawn.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -42,6 +42,8 @@
 
   <body>
 
+    <a class="skip-link" href="#main_content">Skip to main content</a>
+
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
@@ -66,9 +68,9 @@
 
     <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
+      <main id="main_content" class="inner" tabindex="-1">
         {{ content }}
-      </section>
+      </main>
     </div>
 
     {% include footer.html %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -94,6 +94,7 @@
 
     <script src="{{ site.baseurl }}/assets/js/jquery-3.6.0.min.js"></script>
     <script src="{{ site.baseurl }}/assets/js/hide-listings.js"></script>
+    <script src="{{ site.baseurl }}/assets/js/tabbed-interface.js"></script>
     <script src="{{ site.baseurl }}/assets/js/accordion.js"></script>
     <script src="{{ site.baseurl }}/assets/js/candidate-card.js"></script>
   </body>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -5,6 +5,21 @@
 @import "variables";
 @import "typography";
 
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -4rem;
+  z-index: 1000;
+  padding: 0.75rem 1rem;
+  background: $light;
+  color: $dark;
+  border: 2px solid $blue;
+
+  &:focus {
+    top: 1rem;
+  }
+}
+
 /* ---------- MAIN MENU STYLING --------- */
 #main-menu {
   background: $green;
@@ -797,7 +812,7 @@ p.bigtext {
 }
 
 .wrv-accordion {
-  a.toggletop {
+  button.toggletop {
     position: relative;
     display: -webkit-box;
     display: -webkit-flex;
@@ -809,9 +824,12 @@ p.bigtext {
     -ms-flex-direction: column;
     flex-direction: column;
     padding: 1rem 3rem 1rem 1rem;
+    width: 100%;
     color: black;
     font-size: 1.15rem;
     font-weight: 400;
+    text-align: left;
+    border: none;
     border-bottom: 3px solid #156cb2;
     background: #f2f7fa;
     &:hover {

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -164,15 +164,6 @@ nav#toc-tabs {
     min-height: 2em;
     height: auto;
 
-    a {
-      color: inherit;
-      text-decoration: none;
-
-      a:hover {
-        color: inherit;
-      }
-    }
-
     &.substrip {
       display: none;
     }
@@ -207,6 +198,11 @@ nav#toc-tabs {
     border: 0.2em solid var(--blue);
     border-radius: 0.7em;
     text-align: center;
+
+    &:focus-visible {
+      outline: 3px solid $blue;
+      outline-offset: 2px;
+    }
 
     /* 
     border-color: $dark !important;

--- a/docs/assets/js/accordion.js
+++ b/docs/assets/js/accordion.js
@@ -4,20 +4,18 @@
 
 
 function toggleAccordion(){
-    this.classList.toggle('active');
+    var targetId = this.getAttribute("aria-controls");
+    var target = targetId ? document.getElementById(targetId) : this.nextElementSibling;
+    var isExpanded = this.getAttribute("aria-expanded") === "true";
 
-    // Sigh. Maybe I want some elements in between.
-    curr  = this.nextElementSibling;
-    while (curr) { 
-      if (curr.classList.contains("toggle-content")) { 
-         target = curr;
-         break;
-      } 
-      curr = curr.nextElementSibling;
+    if (!target) {
+      return;
+    }
 
-    } // end while
-
-    target.classList.toggle('active');
+    this.classList.toggle('active', !isExpanded);
+    this.setAttribute("aria-expanded", String(!isExpanded));
+    target.hidden = isExpanded;
+    target.classList.toggle('active', !isExpanded);
 }
 
 const toggles = document.querySelectorAll(".toggletop");

--- a/docs/assets/js/candidate-card.js
+++ b/docs/assets/js/candidate-card.js
@@ -20,17 +20,22 @@ function removeFavourite(candidate) {
     localStorage.setItem(WRV_FAVOURITE_KEY, JSON.stringify(favourites));
 }
 
+function setFavouriteState(btn, isFavourited) {
+    btn.toggleClass("favourited", isFavourited);
+    btn.attr("aria-pressed", String(isFavourited));
+    btn.find("i")
+        .toggleClass("fa-solid", isFavourited)
+        .toggleClass("fa-regular", !isFavourited);
+}
+
 function updateFavourites() {
     var favouritedCandidates = parseFavourites();
     $(".favourite-btn[data-candidate-id]").each(function () {
         var btn = $(this);
-        if (favouritedCandidates.includes(btn.attr("data-candidate-id"))) {
-            btn.addClass("favourited");
-            btn.find("i").removeClass("fa-regular").addClass("fa-solid");
-        } else {
-            btn.removeClass("favourited");
-            btn.find("i").removeClass("fa-solid").addClass("fa-regular");
-        }
+        setFavouriteState(
+            btn,
+            favouritedCandidates.includes(btn.attr("data-candidate-id")),
+        );
     });
 }
  
@@ -74,14 +79,13 @@ $(document).ready(function () {
 
     $(".favourite-btn").on("click", function () {
         var candidate = $(this).attr("data-candidate-id");
-        $(this).toggleClass("favourited");
-        var icon = $(this).find("i");
-        if ($(this).hasClass("favourited")) {
-            icon.removeClass("fa-regular").addClass("fa-solid");
-            saveFavourite(candidate);
-        } else {
-            icon.removeClass("fa-solid").addClass("fa-regular");
+        var btn = $(this);
+        if (btn.hasClass("favourited")) {
+            setFavouriteState(btn, false);
             removeFavourite(candidate);
+        } else {
+            setFavouriteState(btn, true);
+            saveFavourite(candidate);
         }
     });
 

--- a/docs/assets/js/hide-listings.js
+++ b/docs/assets/js/hide-listings.js
@@ -266,27 +266,46 @@ $(document).ready(function () {
   (function() {
     var btn = document.getElementById('worksheets-btn');
     var panel = document.getElementById('worksheets-panel');
+    var lastFocusedElement = null;
+    var closeOnScroll = function () {
+      closePanel();
+    };
     if (!btn || !panel) return;
 
 
     function openPanel() {
       var rect = btn.getBoundingClientRect();
+      var closeButton = panel.querySelector('.worksheets-close');
       panel.style.top = rect.top + 'px';
       panel.style.right = (window.innerWidth - rect.right) + 'px';
       panel.hidden = false;
       btn.setAttribute('aria-expanded', 'true');
-      window.addEventListener("scroll", function () {
-        closePanel();
-      });
+      lastFocusedElement = document.activeElement;
+      window.addEventListener("scroll", closeOnScroll);
+      if (closeButton) {
+        closeButton.focus();
+      } else {
+        panel.focus();
+      }
     }
 
     function closePanel() {
       panel.hidden = true;
       btn.setAttribute('aria-expanded', 'false');
+      window.removeEventListener("scroll", closeOnScroll);
+      if (lastFocusedElement && typeof lastFocusedElement.focus === "function") {
+        lastFocusedElement.focus();
+      }
     }
 
     btn.addEventListener('click', function() {
       if (panel.hidden) { openPanel(); } else { closePanel(); }
+    });
+
+    panel.addEventListener('keydown', function(event) {
+      if (event.key === 'Escape') {
+        closePanel();
+      }
     });
 
     panel.querySelectorAll('.worksheets-close').forEach(function(el) {

--- a/docs/assets/js/hide-listings.js
+++ b/docs/assets/js/hide-listings.js
@@ -156,12 +156,53 @@ $(document).ready(function () {
   // ------------------------
   function add_menu_toggle_button() {
     var target = $(this).attr("id");
+    if ($("#main-menu-toggle").length) {
+      return;
+    }
+
     add_ul_toggle_button(
       target,
       "toggle-menu",
-      "toggle main menu",
-      '<i class="fas fa-bars"></i>',
+      "Open main menu",
+      '<i class="fas fa-bars" aria-hidden="true"></i>',
     );
+
+    $("#main-menu-toggle").attr({
+      "aria-controls": target,
+      "aria-expanded": "false",
+      "aria-label": "Open main menu",
+      type: "button",
+    });
+  }
+
+  // ------------------------
+  function set_menu_button_state(isExpanded) {
+    $("#main-menu-toggle").attr({
+      "aria-expanded": String(isExpanded),
+      "aria-label": isExpanded ? "Close main menu" : "Open main menu",
+    });
+    $("#main-menu-ul").attr("aria-hidden", String(!isExpanded));
+  }
+
+  // ------------------------
+  function sync_main_menu_state() {
+    var target_ul = "#main-menu-ul";
+    var toggleButton = document.getElementById("main-menu-toggle");
+    var isDesktop = toggleButton
+      && window.getComputedStyle(toggleButton).display === "none";
+
+    if (isDesktop) {
+      $(target_ul).removeClass("hidden");
+      $(target_ul).show();
+      set_menu_button_state(true);
+      return;
+    }
+
+    if ($(target_ul).hasClass("hidden")) {
+      set_menu_button_state(false);
+    } else {
+      set_menu_button_state(true);
+    }
   }
 
   // ------------------------
@@ -171,9 +212,11 @@ $(document).ready(function () {
     if ($(target_ul).hasClass("hidden")) {
       $(target_ul).removeClass("hidden");
       $(target_ul).slideDown();
+      set_menu_button_state(true);
     } else {
       $(target_ul).addClass("hidden");
       $(target_ul).slideUp();
+      set_menu_button_state(false);
     }
   }
 
@@ -199,6 +242,7 @@ $(document).ready(function () {
   $("#toc-list").each(add_toc_toggle_button);
   $("#main-menu-ul").each(add_menu_toggle_button);
   $(".togglable").each(add_toggle_button);
+  sync_main_menu_state();
 
   $(".toggle-toc").on("click", function (e) {
     toggle_toc("#" + e.target.id);
@@ -207,6 +251,8 @@ $(document).ready(function () {
   $(".toggle-menu").on("click", function (e) {
     toggle_main_menu("#" + e.target.id);
   });
+
+  window.addEventListener("resize", sync_main_menu_state);
 
   $(".toggle-button-background").each(function () {
     toggle_listing(this, "Background", "Show", "Hide");

--- a/docs/assets/js/show-map.js
+++ b/docs/assets/js/show-map.js
@@ -32,6 +32,11 @@ var map = new L.Map('map', {
     center: new L.latLng([43.45850, -80.51511]),
     scrollWheelZoom:false,
   });
+document.getElementById("map").setAttribute("role", "region");
+document.getElementById("map").setAttribute(
+  "aria-label",
+  "Interactive map of Waterloo Region wards",
+);
 
 var baseLayer = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     { attribution: attrib });     //base layer
@@ -82,5 +87,11 @@ $.getJSON("./assets/data/WardBoundaries.geojson", function(data) {
     map.addLayer(geojson);
 
     map.addControl(searchControl);
+
+    var searchInput = document.querySelector("#map-searchbar input");
+    if (searchInput) {
+        searchInput.setAttribute("aria-label", "Search by address to find your ward");
+        searchInput.setAttribute("autocomplete", "street-address");
+    }
 });
 

--- a/docs/assets/js/tabbed-interface.js
+++ b/docs/assets/js/tabbed-interface.js
@@ -1,36 +1,97 @@
-/*** 
- * Implement tabbed interface using Javascript 
+/***
+ * Keep the ward race tabs keyboard- and screen-reader-friendly.
  */
 
-$( document ).ready(function() {
+$(document).ready(function() {
+  function getRadioForTab(tab) {
+    return document.getElementById(tab.getAttribute("for"));
+  }
 
-  function select_tab (evt) { 
-    var target = evt.target
-    // console.log("Target is " + JSON.stringify(target));
-    console.log("Href is " + JSON.stringify(target.href));
+  function syncTabs(nav) {
+    nav.querySelectorAll('[role="tab"]').forEach(function(tab) {
+      var radio = getRadioForTab(tab);
+      var isSelected = radio ? radio.checked : false;
+      tab.setAttribute("aria-selected", String(isSelected));
+      tab.setAttribute("tabindex", isSelected ? "0" : "-1");
 
-    
-    // var target_href = target.split('#').pop();
-    // console.log("Target href is " + target_href);
+      var controlledId = tab.getAttribute("aria-controls");
+      if (!controlledId) {
+        return;
+      }
 
-    var anchor = target.href.split('#').pop();
-    console.log("Anchor is " + anchor);
+      var controlledElement = document.getElementById(controlledId);
+      if (!controlledElement) {
+        return;
+      }
 
-    // STOP from actually visiting the link! Yikes!
-    evt.preventDefault();
+      if (controlledElement.getAttribute("role") === "tabpanel") {
+        controlledElement.setAttribute(
+          "aria-hidden",
+          String(window.getComputedStyle(controlledElement).display === "none"),
+        );
+      } else {
+        controlledElement.setAttribute("aria-hidden", String(!isSelected));
+      }
+    });
+  }
 
-    // Change URL to set new target. Now CSS should work?
-    // NOPE. This does NOT update the target!
-    // https://www.codegenes.net/blog/how-to-prevent-jump-on-an-anchor-click/#51-updating-the-url-hash-without-jumping
-    history.pushState({}, '', '#' + anchor);
+  function selectTab(tab, shouldFocus) {
+    var radio = getRadioForTab(tab);
+    var nav = tab.closest("nav#toc-tabs");
 
-  }; // end select_tab
+    if (!radio || !nav) {
+      return;
+    }
 
+    radio.checked = true;
+    syncTabs(nav);
 
+    if (shouldFocus) {
+      tab.focus();
+    }
+  }
 
-  /* ---- INIT CODE --- */
-  $("[role='tab']").on("click", function (e) { 
-      select_tab ( e );
+  document.querySelectorAll("nav#toc-tabs").forEach(function(nav) {
+    syncTabs(nav);
+
+    nav.querySelectorAll('[role="tab"]').forEach(function(tab) {
+      tab.addEventListener("click", function() {
+        window.requestAnimationFrame(function() {
+          syncTabs(nav);
+        });
+      });
+
+      tab.addEventListener("keydown", function(event) {
+        var tablist = tab.closest('[role="tablist"]');
+        var tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+        var currentIndex = tabs.indexOf(tab);
+        var targetTab = null;
+
+        if (event.key === "ArrowRight") {
+          targetTab = tabs[(currentIndex + 1) % tabs.length];
+        } else if (event.key === "ArrowLeft") {
+          targetTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+        } else if (event.key === "Home") {
+          targetTab = tabs[0];
+        } else if (event.key === "End") {
+          targetTab = tabs[tabs.length - 1];
+        } else if (event.key === " " || event.key === "Enter") {
+          targetTab = tab;
+        }
+
+        if (!targetTab) {
+          return;
+        }
+
+        event.preventDefault();
+        selectTab(targetTab, true);
+      });
+    });
+
+    nav.parentElement.querySelectorAll(".tab-radio").forEach(function(radio) {
+      radio.addEventListener("change", function() {
+        syncTabs(nav);
+      });
+    });
   });
-
 });

--- a/docs/winners.html
+++ b/docs/winners.html
@@ -8,8 +8,11 @@ title: Election Winners
 {% for alias in site.data.internal.results-aliases %}
   {% assign title = site.data.internal.aliases | where: "Alias", alias | first %}
   <div class="accordion-ward">
-    <a class="toggletop">{{ title["Description"] }}</a>
-    <div class="content">
+    <button class="toggletop" type="button" aria-expanded="false"
+      aria-controls="{{ alias | slugify }}-results">
+      {{ title["Description"] }}
+    </button>
+    <div class="content" id="{{ alias | slugify }}-results" hidden>
       <div class="jurisdiction">
         {% for position in site.data.internal.position-tags %}
           {% assign position_aliases = position["Aliases"] | split: "," %}


### PR DESCRIPTION
## Summary
- improve navigation and disclosure semantics with a clearer main menu toggle, skip link support, and button-driven winners accordion behaviour
- improve worksheet and candidate input accessibility by exposing favourite state, labelling editable notes, and tightening related controls
- make ward race tabs keyboard-operable and keep tab state associated with the generated panels for assistive tech

## Test plan
- [x] Reviewed the isolated branch diff against `master`
- [ ] Verify keyboard navigation on the main menu, winners accordion, worksheets, and ward tabs in a browser
- [ ] Run a screen reader spot check for the updated menu, worksheet, and tab states

Made with [Cursor](https://cursor.com)