### PR TITLE
security: add missing workflow permissions blocks

### DIFF
--- a/.github/workflows/python-gen-worksheets.yml
+++ b/.github/workflows/python-gen-worksheets.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/_data/internal/regen-worksheets.txt'
       
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # DISABLE RUN


### PR DESCRIPTION
## Summary

Adds top-level `permissions: contents: read` to `python-gen-worksheets.yml` which was missing an explicit permissions declaration.

Without an explicit `permissions:` block, the workflow inherits the default token permissions. `contents: read` is the correct minimal scope — this workflow only checks out code and runs Python/pip commands.

Resolves `actions/missing-workflow-permissions` code scanning alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
