### PR TITLE
make the hamburger menu float on the right when on mobile

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -2,13 +2,12 @@
 From: https://christianspecht.de/2014/06/18/building-a-pseudo-dynamic-tree-menu-with-jekyll/
 {% endcomment %}
 {% assign navurl = page.url | remove: '.html' %}
-<nav id="main-menu" aria-label="Main menu">
+<nav id="main-menu" class="closed" aria-label="Main menu">
   <div class="inner">
     <ul id="main-menu-ul" class="hidden">
       {%- for item in site.data.internal.menu-layout %}
-        <li><a href="{{ site.baseurl }}{{ item.url }}"
-            {%- if item.url == navurl %} class="current"{% endif -%}>
-            {{- item.text -}}
+      <li><a href="{{ site.baseurl }}{{ item.url }}" {%- if item.url==navurl %} class="current" {% endif -%}>
+          {{- item.text -}}
         </a></li>
       {% endfor -%}
     </ul>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -15,6 +15,12 @@
     padding: 0 2%;
   }
 
+  @media screen and (max-width: 480px) {
+    .inner {
+      min-width: 0;
+    }
+  }
+
   .inner::after {
     /* Clearfix hack so menu button shows */
     content: "";
@@ -63,6 +69,12 @@ button.toggle-menu {
 }
 
 @media screen and (max-width: $menu-breakpoint) {
+  #main-menu.closed {
+    float: right;
+    position: relative;
+    z-index: 1;
+  }
+
   button.toggle-menu {
     display: block;
     float: right;

--- a/docs/assets/js/menu.js
+++ b/docs/assets/js/menu.js
@@ -1,12 +1,16 @@
 $(document).ready(function () {
-
   function add_ul_toggle_button(target, classname, title, inittext) {
     retval =
       '<button data-toc="' +
       target +
       '" ' +
-      'id="' + target + '-btn" ' + 'class="' + classname +
-      '" title="' + title +
+      'id="' +
+      target +
+      '-btn" ' +
+      'class="' +
+      classname +
+      '" title="' +
+      title +
       '" >' +
       inittext +
       "</button>";
@@ -41,6 +45,11 @@ $(document).ready(function () {
   function toggle_main_menu(button_id) {
     var target_ul = "#main-menu-ul";
     var target_button = "#main-menu-ul-btn";
+    if ($("#main-menu").hasClass("closed")) {
+      $("#main-menu").removeClass("closed");
+    } else {
+      $("#main-menu").addClass("closed");
+    }
 
     if ($(target_ul).hasClass("hidden")) {
       $(target_ul).removeClass("hidden");
@@ -81,5 +90,4 @@ $(document).ready(function () {
   $(".toggle-menu").on("click", function (e) {
     toggle_main_menu("#" + e.target.id);
   });
-
 });


### PR DESCRIPTION
# Pull Request

## Summary

The hamburger should shrink down and float right when the webpage doesn't have the width to display the full menu across the page.

Screenshot:
<img width="698" height="587" alt="image" src="https://github.com/user-attachments/assets/340090e9-65d5-47cc-9abc-82314318a2e9" />

